### PR TITLE
Prevent recursive errors

### DIFF
--- a/application/core/MY_Exceptions.php
+++ b/application/core/MY_Exceptions.php
@@ -3,13 +3,16 @@
 class MY_Exceptions extends CI_Exceptions {
     public function show_error($heading, $message, $template = 'error_general', $status_code = 500)
     {
+        // If the function calls itself, this line cleans the stored buffer
+        ob_end_clean();
+        // If there is an error in one of the views,
+        // this prevents the view from being called again
         static $displayed = [
-            'header' => -1,
-            'login_bar' => -1,
-            'error' => -1,
-            'footer' => -1
+            'header' => 0,
+            'login_bar' => 0,
+            'error' => 0,
+            'footer' => 0
         ];
-        $title = $heading;
 		$errors_templates_path = config_item('error_views_path');
 		if (empty($errors_templates_path))
 		{
@@ -44,20 +47,27 @@ class MY_Exceptions extends CI_Exceptions {
             $displayed['header']++;
             if ($displayed['header'] <= 1) {
                 include($common_templates_path.'header.php');
+                $displayed['header']--;
             }
             $displayed['login_bar']++;
             if ($displayed['login_bar'] <= 1) {
                 include($common_templates_path.'login_bar.php');
+                $displayed['login_bar']--;
             }
         }
         $displayed['error']++;
         if ($displayed['error'] <= 1) {
             include($errors_templates_path.$template.'.php');
+            $displayed['error']--;
+        } else {
+            // Basic error display, as the view is not working
+            echo '==='.$heading.'==='.(is_cli() ? PHP_EOL : '<br />').$message;
         }
         if (!is_cli()) {
             $displayed['footer']++;
             if ($displayed['footer'] <= 1) {
                 include($common_templates_path.'footer.php');
+                $displayed['footer']--;
             }
         }
         $buffer = ob_get_contents();

--- a/application/core/MY_Exceptions.php
+++ b/application/core/MY_Exceptions.php
@@ -3,75 +3,45 @@
 class MY_Exceptions extends CI_Exceptions {
     public function show_error($heading, $message, $template = 'error_general', $status_code = 500)
     {
-        // If the function calls itself, this line cleans the stored buffer
-        ob_end_clean();
-        // If there is an error in one of the views,
-        // this prevents the view from being called again
-        static $displayed = [
-            'header' => 0,
-            'login_bar' => 0,
-            'error' => 0,
-            'footer' => 0
-        ];
-		$errors_templates_path = config_item('error_views_path');
-		if (empty($errors_templates_path))
-		{
-			$errors_templates_path = VIEWPATH.'errors'.DIRECTORY_SEPARATOR;
-		}
+        // Common views path, in the common module
+        static $common_views_path = APPPATH.'modules'.DIRECTORY_SEPARATOR.'common'.DIRECTORY_SEPARATOR.'views'.DIRECTORY_SEPARATOR;
+        
+        // Header and footer views displayed before and after the error messages
+        static $header_views = ['header', 'login_bar'];
+        static $footer_views = ['footer'];
 
-		if (is_cli())
-		{
-			$message = "\t".(is_array($message) ? implode("\n\t", $message) : $message);
-			$template = 'cli'.DIRECTORY_SEPARATOR.$template;
-		}
-		else
-		{
-			set_status_header($status_code);
-			$message = '<p>'.(is_array($message) ? implode('</p><p>', $message) : $message).'</p>';
-			$template = 'html'.DIRECTORY_SEPARATOR.$template;
-        }
+        if (is_cli())
+        {
+            return parent::show_error($heading, $message, $template, $status_code);
 
-        // Default to application/views/common
-        $common_templates_path = VIEWPATH.'common'.DIRECTORY_SEPARATOR;
-        if (!file_exists($common_templates_path)) {
-            // Select the views in the common module
-            $common_templates_path = APPPATH.'modules'.DIRECTORY_SEPARATOR.'common'.DIRECTORY_SEPARATOR.'views'.DIRECTORY_SEPARATOR;
-        }
-
-		if (ob_get_level() > $this->ob_level + 1)
-		{
-			ob_end_flush();
-        }
-        ob_start();
-        if (!is_cli()) {
-            $displayed['header']++;
-            if ($displayed['header'] <= 1) {
-                include($common_templates_path.'header.php');
-                $displayed['header']--;
-            }
-            $displayed['login_bar']++;
-            if ($displayed['login_bar'] <= 1) {
-                include($common_templates_path.'login_bar.php');
-                $displayed['login_bar']--;
-            }
-        }
-        $displayed['error']++;
-        if ($displayed['error'] <= 1) {
-            include($errors_templates_path.$template.'.php');
-            $displayed['error']--;
         } else {
-            // Basic error display, as the view is not working
-            echo '==='.$heading.'==='.(is_cli() ? PHP_EOL : '<br />').$message;
-        }
-        if (!is_cli()) {
-            $displayed['footer']++;
-            if ($displayed['footer'] <= 1) {
-                include($common_templates_path.'footer.php');
-                $displayed['footer']--;
+            $message = parent::show_error($heading, $message, $template, $status_code);
+
+            if (ob_get_level() > $this->ob_level + 1)
+            {
+                ob_end_flush();
             }
+
+            ob_start();
+            // Include header views
+            foreach ($header_views as $view)
+            {
+                include($common_views_path.$view.'.php');
+            }
+
+            // Include error message
+            echo $message;
+
+            // Include footer views
+            foreach ($footer_views as $view)
+            {
+                include($common_views_path.$view.'.php');
+            }
+
+            $buffer = ob_get_contents();
+            ob_end_clean();
+
+            return $buffer;
         }
-        $buffer = ob_get_contents();
-        ob_end_clean();
-        return $buffer;
     }
 }

--- a/application/core/MY_Exceptions.php
+++ b/application/core/MY_Exceptions.php
@@ -3,6 +3,12 @@
 class MY_Exceptions extends CI_Exceptions {
     public function show_error($heading, $message, $template = 'error_general', $status_code = 500)
     {
+        static $displayed = [
+            'header' => -1,
+            'login_bar' => -1,
+            'error' => -1,
+            'footer' => -1
+        ];
         $title = $heading;
 		$errors_templates_path = config_item('error_views_path');
 		if (empty($errors_templates_path))
@@ -35,12 +41,24 @@ class MY_Exceptions extends CI_Exceptions {
         }
         ob_start();
         if (!is_cli()) {
-            include($common_templates_path.'header.php');
-            include($common_templates_path.'login_bar.php');
+            $displayed['header']++;
+            if ($displayed['header'] <= 1) {
+                include($common_templates_path.'header.php');
+            }
+            $displayed['login_bar']++;
+            if ($displayed['login_bar'] <= 1) {
+                include($common_templates_path.'login_bar.php');
+            }
         }
-        include($errors_templates_path.$template.'.php');
+        $displayed['error']++;
+        if ($displayed['error'] <= 1) {
+            include($errors_templates_path.$template.'.php');
+        }
+        $displayed['footer']++;
         if (!is_cli()) {
-            include($common_templates_path.'footer.php');
+            if ($displayed['footer'] <= 1) {
+                include($common_templates_path.'footer.php');
+            }
         }
         $buffer = ob_get_contents();
         ob_end_clean();

--- a/application/core/MY_Exceptions.php
+++ b/application/core/MY_Exceptions.php
@@ -54,8 +54,8 @@ class MY_Exceptions extends CI_Exceptions {
         if ($displayed['error'] <= 1) {
             include($errors_templates_path.$template.'.php');
         }
-        $displayed['footer']++;
         if (!is_cli()) {
+            $displayed['footer']++;
             if ($displayed['footer'] <= 1) {
                 include($common_templates_path.'footer.php');
             }

--- a/application/modules/common/views/header.php
+++ b/application/modules/common/views/header.php
@@ -10,7 +10,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
 
     <title><?php
-        if (is_null($title) || $title == '') {
+        if (!isset($title) || is_null($title) || $title == '') {
             echo lang('page_prefix');
         } else {
             echo lang('page_prefix').' - '.$title;


### PR DESCRIPTION
Prevent recursive errors by adding a check in MY_Exceptions.

The error display will abort and go to the default display if there is an error in any of the common view

Closes #30